### PR TITLE
add utils for a range of ip addresses

### DIFF
--- a/raccoon_src/utils/help_utils.py
+++ b/raccoon_src/utils/help_utils.py
@@ -1,4 +1,6 @@
 import os
+import struct
+import socket
 import distutils.spawn
 from collections import Counter
 from subprocess import PIPE, check_call, CalledProcessError
@@ -10,7 +12,61 @@ from raccoon_src.utils.request_handler import RequestHandler
 class HelpUtilities:
 
     PATH = ""
+    
+    @staticmethod
+    def ip_to_int(ip_address):
+        """
 
+        >>> HelpUtilities.ip_to_int("192.168.0.0")
+        3232235520L
+        >>> HelpUtilities.ip_to_int("192.168.255.255")
+        3232301055L
+
+        :param ip_address: a quad dotted ip address
+        :return: an integer (long) representation of that ip address's bits
+        """
+        return struct.unpack('!I', socket.inet_aton(ip_address))[0]
+
+    @staticmethod
+    def int_to_ip(int_value):
+        """
+
+        >>> HelpUtilities.int_to_ip(3232235520)
+        '192.168.0.0'
+        >>> HelpUtilities.int_to_ip(3232301055)
+        '192.168.255.255'
+
+        :param int_value: an integer
+        :return: string quad dotted ip address
+        """
+
+        return socket.inet_ntoa(struct.pack('!I', int_value))
+
+    @staticmethod
+    def iter_ip_range(start_address,end_address):
+        """
+
+        :param start_address:
+        :param end_address:
+        :return:
+        """
+        for i in range(HelpUtilities.ip_to_int(start_address),HelpUtilities.ip_to_int(end_address)+1):
+            yield HelpUtilities.int_to_ip(i)
+
+    @staticmethod
+    def count_ips_in_range(start_address,end_address):
+        """
+        >>> HelpUtilities.count_ips_in_range('192.168.1.10','192.168.255.10')
+        65024L
+
+
+        :param start_address: a quad dotted ip address string
+        :param end_address: a quad dotted ip address string
+        :return:
+        """
+        return HelpUtilities.ip_to_int(end_address)-HelpUtilities.ip_to_int(start_address)
+
+        
     @classmethod
     def validate_target_is_up(cls, host):
         cmd = "ping -c 1 {}".format(host.target)


### PR DESCRIPTION
 IP ranges support (from todos and roadmaps ...)

no non-builtin imports required, and includes tests