### PR TITLE
remove sys.path hack:

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ You can also clone the GitHub repository for the latest features and changes:<br
 ```
 git clone https://github.com/evyatarmeged/Raccoon.git
 cd Raccoon
-python raccoon_src/main.py
+python setup.py develop
+raccoon [OPTIONS]
 ```
 For docker installation:<br>
 ```

--- a/README.md
+++ b/README.md
@@ -70,15 +70,18 @@ You can also clone the GitHub repository for the latest features and changes:<br
 ```
 git clone https://github.com/evyatarmeged/Raccoon.git
 cd Raccoon
-python setup.py develop
-raccoon [OPTIONS]
+python setup.py install # Subsequent changes to the source code will not be reflected in calls to raccoon when this is used
+# Or
+python setup.py develop # Changes to code will be reflected in calls to raccoon. This can be undone by using python setup.py develop --uninstall
+# Finally
+raccoon [OPTIONS] [TARGET]
 ```
 For docker installation:<br>
 ```
 # Build the docker image
 docker build -t evyatarmeged/raccoon .
 # Run a scan, As this a non-root container we need to save the output under the user's home which is /home/raccoon
-docker run --name raccoon evyatarmeged/raccoon:latest -t example.com -o /home/raccoon
+docker run --name raccoon evyatarmeged/raccoon:latest  example.com -o /home/raccoon
 ```
 
 ##### Prerequisites
@@ -88,11 +91,10 @@ and features. It is mandatory that you have it installed before running Raccoon.
 
 ### Usage
 ```
-Usage: raccoon [OPTIONS]
+Usage: raccoon [OPTIONS] [TARGET]
 
 Options:
   --version                      Show the version and exit.
-  -t, --target TEXT              Target to scan  [required]
   -d, --dns-records TEXT         Comma separated DNS records to query.
                                  Defaults to: A,MX,NS,CNAME,SOA,TXT
   --tor-routing                  Route HTTP traffic through Tor (uses port

--- a/raccoon_src/main.py
+++ b/raccoon_src/main.py
@@ -5,9 +5,6 @@ import click
 import sys
 import os
 
-# Python imports will be the end of us all
-sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
-
 from raccoon_src.utils.coloring import COLOR, COLORED_COMBOS
 from raccoon_src.utils.exceptions import RaccoonException, HostHandlerException
 from raccoon_src.utils.request_handler import RequestHandler


### PR DESCRIPTION
  - recommend use of python setup.py install/develop

Python imports need not be the death of us all. If one uses `python setup.py develop` on a developer's machine, or installs with the recommended method of `python setup.py install` (as will be the case for anyone using pip), no sys.path hacking is needed to access modules within the source code.