### PR TITLE
convert -t to positional argument, target

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,10 @@ and features. It is mandatory that you have it installed before running Raccoon.
 
 ### Usage
 ```
-Usage: raccoon [OPTIONS]
+Usage: raccoon [OPTIONS] TARGET
 
 Options:
   --version                      Show the version and exit.
-  -t, --target TEXT              Target to scan  [required]
   -d, --dns-records TEXT         Comma separated DNS records to query.
                                  Defaults to: A,MX,NS,CNAME,SOA,TXT
   --tor-routing                  Route HTTP traffic through Tor (uses port

--- a/raccoon_src/main.py
+++ b/raccoon_src/main.py
@@ -45,7 +45,7 @@ https://github.com/evyatarmeged/Raccoon
 
 @click.command()
 @click.version_option("0.8.3")
-@click.option("-t", "--target", required=True, help="Target to scan")
+@click.argument("target")
 @click.option("-d", "--dns-records", default="A,MX,NS,CNAME,SOA,TXT",
               help="Comma separated DNS records to query. Defaults to: A,MX,NS,CNAME,SOA,TXT")
 @click.option("--tor-routing", is_flag=True, help="Route HTTP traffic through Tor (uses port 9050)."


### PR DESCRIPTION
It's more conventional to accept required options as positional arguments. I think this also makes the usage string more readable.