### PR TITLE
Added nmap-scripts package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.5-alpine
 LABEL maintainer="Mostafa Hussein <mostafa.hussein91@gmail.com>"
-RUN apk add --no-cache gcc musl-dev libxml2-dev libxslt-dev nmap openssl
+RUN apk add --no-cache gcc musl-dev libxml2-dev libxslt-dev nmap nmap-scripts openssl
 RUN pip install raccoon-scanner
 RUN adduser -D raccoon
 USER raccoon


### PR DESCRIPTION
The current Docker version throws the following error `could not locate nse_main.lua`. Resolved by including the `nmap-scripts` package when building the image.